### PR TITLE
Update version number in manifest to 1.17

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Suspicious Site Reporter",
-    "version": "1.15",
+    "version": "1.17",
     "description": "Extension for reporting suspicious sites to Safe Browsing.",
     "permissions": [
         "https://safebrowsing.google.com/*",


### PR DESCRIPTION
Due to some bug fixes in the release (build process issues), the version uploaded to the web store is 1.17. The code in this repo still matches the live version.