### PR TITLE
Performance: Only recompute when needed

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -216,14 +216,14 @@ class Background {
      * @param {!Tab} tab A Chrome Tab instance.
      */
     const setBrowserActionAndIcon = (tab) => {
-      if (!tab.url.startsWith('http')) {
+      if (!tab.url || !tab.url.startsWith('http')) {
         chrome.browserAction.disable(tab.id);
       } else {
         chrome.browserAction.enable(tab.id);
         this.getAlertBadge_(tab);
       }
     };
-    chrome.tabs.query({}, (tabs) => {
+    chrome.tabs.query({active:true}, (tabs) => {
       tabs.forEach((tab) => {
         setBrowserActionAndIcon(tab);
       });
@@ -234,7 +234,9 @@ class Background {
       });
     });
     chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-      setBrowserActionAndIcon(tab);
+      if (changeInfo.url && tab.active) {
+        setBrowserActionAndIcon(tab);
+      }
     });
   }
 }

--- a/extension/do.sh
+++ b/extension/do.sh
@@ -106,15 +106,15 @@ ssr_install_deps() {
   mkdir protoc; cd protoc
   OS="$1"
   if [ ! $OS == "win" ]; then
-    curl https://github.com/google/protobuf/releases/download/v3.8.0/protoc-3.8.0-$OS-x86_64.zip -O
+    curl https://github.com/google/protobuf/releases/download/v3.8.0/protoc-3.8.0-$OS-x86_64.zip -O -L
     unzip protoc-3.8.0-$OS-x86_64.zip
     rm protoc-3.8.0-$OS-x86_64.zip
   else
-    curl https://github.com/google/protobuf/releases/download/v3.8.0/protoc-3.8.0-win64.zip -O
+    curl https://github.com/google/protobuf/releases/download/v3.8.0/protoc-3.8.0-win64.zip -O -L
     unzip protoc-3.8.0-win64.zip
     rm protoc-3.8.0-win64.zip
   fi
-  curl https://github.com/google/protobuf/releases/download/v3.8.0/protobuf-js-3.8.0.zip -O
+  curl https://github.com/google/protobuf/releases/download/v3.8.0/protobuf-js-3.8.0.zip -O -L
   unzip protobuf-js-3.8.0.zip
   rm protobuf-js-3.8.0.zip
   cd ../..


### PR DESCRIPTION
Don't recompute scores for tabs that aren't the foreground.

Don't recompute scores when the URL hasn't changed.

Fixes #32