### PR TITLE
Fetch redirect URLs from referrer chain as setup for redirect-related signals

### DIFF
--- a/extension/alerts_test.js
+++ b/extension/alerts_test.js
@@ -32,6 +32,10 @@ describe('alerts', () => {
       callback([
         {url: 'http://visitedyesterday.test/page1'},
         {url: 'http://visitedthreemonthsago.test/page1'},
+        {
+          url:
+              'http://very-very-long-subdomain.many.many.subdomains.example.com'
+        },
       ]);
     });
   });
@@ -132,16 +136,67 @@ describe('alerts', () => {
        });
   });
 
-  describe('computeAlerts', () => {
-    it('should return the correct list of alerts', async (done) => {
-      alerts.computeAlerts('http://visitedyesterday.test').then((response) => {
-        expect(response.length).toEqual(1);
-      });
+  describe('fetchRedirectUrls', () => {
+    it('should return client and server redirect URLs from the referrer',
+       (done) => {
+         chrome.safeBrowsingPrivate = {
+           getReferrerChain: jasmine.createSpy(),
+         };
+         chrome.safeBrowsingPrivate.getReferrerChain.and.callFake(
+             (tabId, callback) => {
+               callback([
+                 {
+                   urlType: 'CLIENT_REDIRECT',
+                   referrerUrl: 'test.com',
+                   serverRedirectChain: [
+                     {url: 'url-shortener.test'}, {url: 'redirect-test.com'}
+                   ],
+                 },
+                 {
+                   urlType: 'LANDING_PAGE',
+                   referrerUrl: 'test.com',
+                 },
+               ]);
+             });
 
-      alerts.computeAlerts('http://visitedtoday.test').then((response) => {
-        expect(response.length).toEqual(2);
-        expect(response).toContain(alerts.ALERT_MESSAGES['notVisitedBefore']);
-      });
+         alerts.fetchRedirectUrls('redirect-test.com', /* tabId= */ 123)
+             .then((response) => {
+               expect(response.size).toEqual(2);
+               expect(response).toEqual(
+                   new Set(['test.com', 'url-shortener.test']));
+               done();
+             });
+       });
+  });
+
+  describe('computeAlerts', () => {
+    // For this test case, the redirect and top site alerts will fire
+    // due to mock setup complexity, while the remaining alerts trigger as
+    // expected based on the URL passed into the computeAlerts function
+    // and setup in the beforeEach at the top of this file.
+    it('should return the correct list of alerts', async (done) => {
+      alerts
+          .computeAlerts(
+              'http://very-very-long-subdomain.many.many.subdomains.example.com',
+              /* tabId= */ 123)
+          .then((response) => {
+            expect(response.length).toEqual(3);
+            expect(response).toContain(alerts.ALERT_MESSAGES['longSubdomains']);
+            expect(response).toContain(alerts.ALERT_MESSAGES['notTopSite']);
+            expect(response).toContain(alerts.ALERT_MESSAGES['manySubdomains']);
+          });
+
+      alerts
+          .computeAlerts(
+              'http://new-few-very-long-subdomain.example.com',
+              /* tabId= */ 123)
+          .then((response) => {
+            expect(response.length).toEqual(3);
+            expect(response).toContain(alerts.ALERT_MESSAGES['longSubdomains']);
+            expect(response).toContain(alerts.ALERT_MESSAGES['notTopSite']);
+            expect(response).toContain(
+                alerts.ALERT_MESSAGES['notVisitedBefore']);
+          });
 
       done();
     });

--- a/extension/background.js
+++ b/extension/background.js
@@ -105,7 +105,7 @@ class Background {
    * @private
    */
   async getAlertBadge_(tab) {
-    const alertList = await alerts.computeAlerts(tab.url);
+    const alertList = await alerts.computeAlerts(tab.url, tab.id);
     this.alerts = alertList;
 
     /**

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -271,9 +271,10 @@ class Popup {
   /**
    * Populates alert list.
    * @param {string} url The URL of the current tab.
+   * @param {number} tabId The ID of the current tab.
    * @private
    */
-  populateAlerts_(url) {
+  populateAlerts_(url, tabId) {
     let port = chrome.extension.connect({name: 'Site info'});
     port.postMessage({siteInfo: true});
     port.onMessage.addListener(async (message) => {
@@ -282,7 +283,7 @@ class Popup {
       // background page, recompute the alert list now.
       if (!fetchedAlerts) {
         alerts.setTopSitesList();
-        const computedAlerts = await alerts.computeAlerts(url);
+        const computedAlerts = await alerts.computeAlerts(url, tabId);
         fetchedAlerts = computedAlerts;
       }
       if (!fetchedAlerts || fetchedAlerts.length === 0) {
@@ -343,7 +344,7 @@ class Popup {
     const popup = this;
     chrome.tabs.query({'active': true, 'currentWindow': true}, (tabs) => {
       const currentTab = tabs[0];
-      popup.populateAlerts_(currentTab.url);
+      popup.populateAlerts_(currentTab.url, currentTab.id);
       urlPreview.textContent = removeUserInfo(currentTab.url);
       if (isMultiline(urlPreview)) urlPreview.classList.add('multiline');
       popup.generateScreenshotPreview_(currentTab);


### PR DESCRIPTION
Fetch redirect URLs from referrer chain and alert if there are many redirects

Add a new signal examining the redirect chain to provide more information that's helpful in determining if a site is suspicious. This patch also provides the setup for other signals related to the redirect chain, such as whether the site redirected through a TLD associated with a high rate of spam/abuse.