### PR TITLE
Add alert for when a site is redirected through multiple URL shorteners

### DIFF
--- a/extension/alerts_test.js
+++ b/extension/alerts_test.js
@@ -136,6 +136,28 @@ describe('alerts', () => {
        });
   });
 
+  describe('hasMultipleUrlShortenerRedirects', () => {
+    it('should return true when the site has more than one redirect through a URL shortener',
+       () => {
+         const redirectUrls = new Set([
+           'http://goo.gl/test', 'https://goo.gl/test',
+           'https://goo.gl/redirect-test'
+         ]);
+         expect(alerts.hasMultipleUrlShortenerRedirects(redirectUrls))
+             .toEqual(true);
+       });
+
+    it('should return false when the site has one redirect through a URL shortener',
+       () => {
+         const redirectUrls = new Set([
+           'http://goo.gl/test', 'https://goo.gl/test',
+           'https://redirect-test.com'
+         ]);
+         expect(alerts.hasMultipleUrlShortenerRedirects(redirectUrls))
+             .toEqual(false);
+       });
+  });
+
   describe('fetchRedirectUrls', () => {
     it('should return client and server redirect URLs from the referrer',
        (done) => {


### PR DESCRIPTION
Add alert for when a site is redirected through multiple URL shorteners

This is a new signal that a site may be suspicious. If a site redirects through more than 1 URL shortened by a common URL shortener, excluding HTTPS redirects, it will be flagged.