### PR TITLE
Add signal for redirects initiated from outside program or webmail

### DIFF
--- a/extension/dev_manifest.json
+++ b/extension/dev_manifest.json
@@ -1,21 +1,21 @@
 {
-    "name": "Test Suspicious Site Reporter",
-    "version": "1.0",
-    "description": "Extension for reporting suspicious sites to Safe Browsing.",
-    "permissions": [
-        "https://test-safebrowsing.google.com/*",
-        "activeTab",
-        "history",
-        "safeBrowsingPrivate",
-        "tabs"
-    ],
-    "background": {
-        "scripts": ["alerts_bin.js", "dev_background_bin.js"],
-        "persistent": false
-    },
-    "browser_action": {
-	"default_popup": "popup.html",
-	"default_icon": {
+  "name": "Test Suspicious Site Reporter",
+  "version": "1.0",
+  "description": "Extension for reporting suspicious sites to Safe Browsing.",
+  "permissions": [
+      "https://test-safebrowsing.google.com/*",
+      "activeTab",
+      "history",
+      "safeBrowsingPrivate",
+      "tabs"
+  ],
+  "background": {
+      "scripts": ["alerts_bin.js", "dev_background_bin.js"],
+      "persistent": false
+  },
+  "browser_action": {
+  "default_popup": "popup.html",
+  "default_icon": {
             "16": "images/grayflag16.png",
             "48": "images/grayflag48.png",
             "128": "images/grayflag128.png"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,21 +1,21 @@
 {
-    "name": "Suspicious Site Reporter",
-    "version": "1.20",
-    "description": "Extension for reporting suspicious sites to Safe Browsing.",
-    "permissions": [
-        "https://safebrowsing.google.com/*",
-        "activeTab",
-        "history",
-        "safeBrowsingPrivate",
-        "tabs"
-    ],
-    "background": {
-        "scripts": ["alerts_bin.js", "background_bin.js"],
-        "persistent": false
-    },
-    "browser_action": {
-	"default_popup": "popup.html",
-	"default_icon": {
+  "name": "Suspicious Site Reporter",
+  "version": "1.21",
+  "description": "Extension for reporting suspicious sites to Safe Browsing.",
+  "permissions": [
+      "https://safebrowsing.google.com/*",
+      "activeTab",
+      "history",
+      "safeBrowsingPrivate",
+      "tabs"
+  ],
+  "background": {
+      "scripts": ["alerts_bin.js", "background_bin.js"],
+      "persistent": false
+  },
+  "browser_action": {
+  "default_popup": "popup.html",
+  "default_icon": {
             "16": "images/grayflag16.png",
             "48": "images/grayflag48.png",
             "128": "images/grayflag128.png"


### PR DESCRIPTION
Add signal for redirects initiated from outside program or webmail

Alerts users when redirects initiated from outside program or webmail, and the final URL is not a top domain. List is small to start, since it's non-trivial to figure out what domains are webmail.